### PR TITLE
Add URL links to bread crumbs in `Suministro` detail (#61)

### DIFF
--- a/suministrospr/suministros/templates/suministros/suministro_detail.html
+++ b/suministrospr/suministros/templates/suministros/suministro_detail.html
@@ -8,10 +8,14 @@
 </div>
 <div class="flex justify-center">
   <div class="flex flex-row text-sm text-gray-600">
-    <div>></div>
-    <div class="ml-2">{{ object.get_municipality_display }}</div>
+    <div class="ml-2">
+      <a href="{% url 'suministro-municipio-list' object.municipality|slugify %}">{{ object.get_municipality_display }}</a>
+    </div>
     <div class="ml-2">></div>
-    <div class="ml-2">{{ object.title }}</div>
+    <div class="ml-2">
+      <a href="{% url 'suministro-detail' object.slug %}">{{ object.title }}</a>
+    </div>
+   </div>
   </div>
 </div>
 <div class="flex justify-center mt-10">


### PR DESCRIPTION
<img width="913" alt="Screen Shot 2020-01-15 at 3 53 57 PM" src="https://user-images.githubusercontent.com/301949/72466810-040db380-37b0-11ea-9b18-cdbc84075836.png">

It definitely needs some styling but the links are working.