### PR TITLE
Reinstall django-taggit for migrations

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -27,6 +27,7 @@ django-redis = "==4.11.0"
 django-reversion = "==3.0.5"
 sentry-sdk = "==0.14.0"
 django-select2 = "==7.2.0"
+django-taggit = "*"
 
 [pipenv]
 allow_prereleases = true

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "0c4bd22bf4831b174192094ec96674143907af6b6704330c0077e59a1e2ddeaf"
+            "sha256": "d40d47c53e65f833dfecab3d164717863d02ba48d66882040f01f0b1d02a6e5a"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -114,6 +114,14 @@
             ],
             "index": "pypi",
             "version": "==7.2.0"
+        },
+        "django-taggit": {
+            "hashes": [
+                "sha256:4186a6ce1e1e9af5e2db8dd3479c5d31fa11a87d216a2ce5089ba3afde24a2c5",
+                "sha256:bd1ec80b813d60adadaa94dcce4bfd971cb4ae717b07e69fedbd38d417deb6e9"
+            ],
+            "index": "pypi",
+            "version": "==1.2.0"
         },
         "gunicorn": {
             "hashes": [

--- a/suministrospr/settings.py
+++ b/suministrospr/settings.py
@@ -38,6 +38,7 @@ class Common(Configuration):
         "django_extensions",
         "debug_toolbar",
         "ckeditor",
+        "taggit",
         "reversion",
         "django_select2",
         "suministrospr.users",


### PR DESCRIPTION
Migrations are not succeeding because the unsquashed migration files still depend on this package. We can remove it in the same PR where we remove the old migration files.