### PR TITLE
Add setup for heroku container stack

### DIFF
--- a/app.json
+++ b/app.json
@@ -3,6 +3,7 @@
   "website": "https://suministrospr.com",
   "repository": "https://github.com/code4puertorico/suministrospr",
   "success_url": "/",
+  "stack": "container",
   "scripts": {
     "postdeploy": "./bin/heroku-postdeploy"
   },

--- a/heroku.yml
+++ b/heroku.yml
@@ -1,0 +1,9 @@
+build:
+  docker:
+    web: Dockerfile
+release:
+  image: web
+  command:
+    - python manage.py collectstatic --noinput
+run:
+  web: gunicorn -b 0.0.0.0:$PORT suministrospr.wsgi


### PR DESCRIPTION
This will allow running on heroku as a `container` stack. On `git push`, heroku will build our Dockerfile, run `collectstatic` in the release phase, and run server.

Will also allow for installing `gettext` for #122 