### PR TITLE
Make municipalities collapsible on mobile

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -167,6 +167,55 @@ footer .container {
   font-size: 1rem;
 }
 
+.grid__column--toggle {
+  display: none;
+}
+
+@media (max-width: 767px) {
+  .grid__column--cell {
+    position: relative;
+  }
+
+  .grid__column--header {
+    padding-right: 1.5rem;
+  }
+
+  .grid__column--cell ul {
+    display: none;
+  }
+
+  label.grid__column--toggle {
+    cursor: pointer;
+    display: block;
+    position: absolute;
+    right: 0;
+    top: 0;
+    height: 1.5rem;
+    width: 1.5rem;
+    padding: 1rem 0.5rem;
+    box-sizing: content-box;
+  }
+
+  label.grid__column--toggle .svg {
+    color: #4a5568;
+    height: 100%;
+    transition: transform 0.2s;
+  }
+
+  input.grid__column--toggle:not(:checked) ~ .grid__column--header {
+    border-bottom: none;
+  }
+
+  input.grid__column--toggle:checked ~ .grid__column--header label.grid__column--toggle .svg {
+    transform: rotate(180deg);
+  }
+
+  input.grid__column--toggle:checked ~ ul {
+    display: block;
+  }
+}
+
+
 /* suministro_municipio_list.html */
 
 .footer__main--paragraph {

--- a/suministrospr/suministros/templates/suministros/suministro_list.html
+++ b/suministrospr/suministros/templates/suministros/suministro_list.html
@@ -57,7 +57,13 @@
         {% for group in sorted_results %}
           <div class="main__munigrid grid__column">
             <div class="grid__column--cell">
+              <input type="checkbox" id="toggle-{{ group.municipality|slugify }}" class="grid__column--toggle" />
               <div class="grid__column--header">
+                <label for="toggle-{{ group.municipality|slugify }}" class="grid__column--toggle">
+                  <div class="svg">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M9.293 12.95l.707.707L15.657 8l-1.414-1.414L10 10.828 5.757 6.586 4.343 8z"/></svg>
+                  </div>
+                </label>
                 <img src="{% escudo_static group.municipality %}" alt="{{ group.municipality }}" >
                 <h3>
                   <a href="{% url 'suministro-municipio-list' group.municipality|slugify %}">{{ group.municipality }}</a>


### PR DESCRIPTION
Addresses #103 
* Collapse municipalities on mobile and allow toggling open on icon tap
* Re-used svg chevron icon vs design proposed in mockups for UI consistency

Tested across the “default” set of browsers on browser stack including IE11. Not sure if there’s a supported browsers list.

Note: usability is a little weird that clicking left side takes you to a new page, clicking right side toggles section. Proposed design might make this distinction a little clearer, but it didn't seen worth the tradeoff of introducing a new, eye-catching UI element.

<img width="360" alt="Screen Shot 2020-01-28 at 3 00 19 PM" src="https://user-images.githubusercontent.com/66348/73305385-5c9d7180-41f0-11ea-8860-077629db7322.png">
