### PR TITLE
Create stale.yml

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,21 @@
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: "0 0 * * 0"
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/stale@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'This Issue is being marked as Stale because it has 30 days without any interaction. CC: @froi @jpadilla'
+        stale-pr-message: 'This Pull Request is being marked as Stale because it has 30 days without any interaction.  CC: @froi @jpadilla'
+        stale-issue-label: 'no-issue-activity'
+        stale-pr-label: 'no-pr-activity'
+        days-before-stale: 30
+        days-before-close: 7


### PR DESCRIPTION
Initial commit for Stale action.

This action will mark issues and PRs as stale after 30 days. It will run every Sunday at 00:00 (12am).
 
Issues and PRs will then be closed after 7 days from the time that they are marked stale.

More info about this action here: https://github.com/actions/stale