### PR TITLE
fix: invalidate cache with lang prefix

### DIFF
--- a/suministrospr/suministros/signals.py
+++ b/suministrospr/suministros/signals.py
@@ -7,9 +7,12 @@ from .models import Municipality, Suministro, Tag
 def suministro_invalidate_cache(sender, instance, created=None, **kwargs):
     cache.delete_many(
         [
-            "suministro-list",
-            f"suministro-municipio-list:{instance.municipality.slug}",
-            f"suministro-detail:{instance.slug}",
+            "en:suministro-list",
+            "es:suministro-list",
+            f"en:suministro-municipio-list:{instance.municipality.slug}",
+            f"es:suministro-municipio-list:{instance.municipality.slug}",
+            f"en:suministro-detail:{instance.slug}",
+            f"es:suministro-detail:{instance.slug}",
         ]
     )
 
@@ -18,7 +21,8 @@ def suministro_tags_invalidate_cache(sender, instance, action, **kwargs):
     if action in ["post_save", "post_delete"]:
         pk_set = kwargs.get("pk_set")
         cache_keys = [
-            f"suministro-detail:{instance.slug}",
+            f"en:suministro-detail:{instance.slug}",
+            f"es:suministro-detail:{instance.slug}",
         ]
 
         if pk_set:
@@ -27,18 +31,33 @@ def suministro_tags_invalidate_cache(sender, instance, action, **kwargs):
             )
 
             for slug in tag_slugs_changed:
-                cache_keys.extend([f"suministro-search:{slug}"])
+                cache_keys.extend(
+                    [f"en:suministro-search:{slug}", f"es:suministro-search:{slug}"]
+                )
 
         cache.delete_many(cache_keys)
 
 
 def municipality_invalidate_cache(sender, instance, **kwargs):
-    cache.delete_many(["suministro-list", f"suministro-municipio-list:{instance.slug}"])
+    cache.delete_many(
+        [
+            "en:suministro-list",
+            "es:suministro-list",
+            f"en:suministro-municipio-list:{instance.slug}"
+            f"es:suministro-municipio-list:{instance.slug}",
+        ]
+    )
 
 
 def tag_invalidate_cache(sender, instance, **kwargs):
     cache.delete_many(
-        ["suministro-list", "forms:filter-tags", f"suministro-search:{instance.slug}"]
+        [
+            "en:suministro-list",
+            "es:suministro-list",
+            f"en:suministro-search:{instance.slug}"
+            f"es:suministro-search:{instance.slug}"
+            "forms:filter-tags",
+        ]
     )
 
 

--- a/suministrospr/suministros/tests/test_views.py
+++ b/suministrospr/suministros/tests/test_views.py
@@ -56,7 +56,7 @@ class TestSuministroList:
         assert response.status_code == 200
 
     def test_order_by_count(self, rf, django_assert_num_queries):
-        with django_assert_num_queries(1):
+        with django_assert_num_queries(3):
             request = rf.get(self.url)
             response = SuministroList.as_view()(request)
 
@@ -130,13 +130,13 @@ class TestSuministroSearch:
         assert results_municipalities == 2
 
     def test_num_queries_without_filter(self, rf, django_assert_num_queries):
-        with django_assert_num_queries(3):
+        with django_assert_num_queries(2):
             request = rf.get(self.url)
             response = SuministroSearch.as_view()(request)
             assert response.rendered_content
 
     def test_num_queries_with_filter(self, rf, django_assert_num_queries):
-        with django_assert_num_queries(3):
+        with django_assert_num_queries(2):
             request = rf.get(self.url, {"tag": "tag_a"})
             response = SuministroSearch.as_view()(request)
             assert response.rendered_content

--- a/suministrospr/suministros/views.py
+++ b/suministrospr/suministros/views.py
@@ -62,7 +62,8 @@ class SuministroByMunicipalityList(CacheMixin, ListView):
     cache_key = "suministro-municipio-list"
 
     def get_cache_key(self):
-        return f"{self.cache_key}:{self.kwargs['municipality']}"
+        cache_key = super().get_cache_key()
+        return f"{cache_key}:{self.kwargs['municipality']}"
 
     def get_queryset(self):
         return (
@@ -86,7 +87,8 @@ class SuministroDetail(CacheMixin, DetailView):
     )
 
     def get_cache_key(self):
-        return f"{self.cache_key}:{self.kwargs['slug']}"
+        cache_key = super().get_cache_key()
+        return f"{cache_key}:{self.kwargs['slug']}"
 
 
 class SuministroCreate(RevisionMixin, CreateView):
@@ -110,7 +112,7 @@ class SuministroSearch(CacheMixin, TemplateView):
     cache_key = "suministro-search"
 
     def get_cache_key(self):
-        cache_key = self.cache_key
+        cache_key = super().get_cache_key()
         tag = self.request.GET.get("tag")
 
         if tag:

--- a/suministrospr/utils/mixins.py
+++ b/suministrospr/utils/mixins.py
@@ -10,7 +10,7 @@ class CacheMixin:
 
     def get_cache_key(self):
         language_code = get_language()
-        return f"{self.cache_key}:{language_code}"
+        return f"{language_code}:{self.cache_key}"
 
     def get_cache_data(self):
         cache_key = self.get_cache_key()


### PR DESCRIPTION
- Reorder cache keys: `${lang}:${key}:${detail}`
- Correctly inherit from cache mixin when overriding `get_cache_key()` in views.
- Invalidate cache keys with language prefix where applicable.